### PR TITLE
Inject content into vue files

### DIFF
--- a/packages/core/parcel-bundler/src/assets/StylusAsset.js
+++ b/packages/core/parcel-bundler/src/assets/StylusAsset.js
@@ -5,6 +5,7 @@ const Resolver = require('../Resolver');
 const fs = require('@parcel/fs');
 const {dirname, resolve, relative} = require('path');
 const {isGlob, glob} = require('../utils/glob');
+const {EOL} = require('os');
 
 const URL_RE = /^(?:url\s*\(\s*)?['"]?(?:[#/]|(?:https?:)?\/\/)/i;
 
@@ -20,6 +21,10 @@ class StylusAsset extends Asset {
     let opts = await this.getConfig(['.stylusrc', '.stylusrc.js'], {
       packageKey: 'stylus'
     });
+    // inject content at beginning of stylus files
+    if (opts && opts.inject) {
+      code = opts.inject + EOL + code;
+    }
     let style = stylus(code, opts);
     style.set('filename', this.name);
     style.set('include css', true);

--- a/packages/core/parcel-bundler/src/assets/VueAsset.js
+++ b/packages/core/parcel-bundler/src/assets/VueAsset.js
@@ -17,6 +17,17 @@ class VueAsset extends Asset {
     );
     this.vue = await localRequire('@vue/component-compiler-utils', this.name);
 
+    // handle mighty vue (initial, pretty basic version)
+    const regx = /(?<=\n|^)(template|script|style)(?:.*\n)([\s\S]*?)(\n(?=\S)|$)/g;
+    const lang = {
+      template: 'pug',
+      script: 'coffee',
+      style: 'stylus'
+    };
+    code = code.replace(regx, function(...hits) {
+      return `<${hits[1]} lang='${lang[hits[1]]}'>\n${hits[2]}</${hits[1]}>\n`;
+    });
+
     return this.vue.parse({
       source: code,
       needMap: this.options.sourceMaps,


### PR DESCRIPTION
# ↪️ Pull Request

This PR addresses two areas releated to injecting content into `vue` files:

1. **Allows you to inject a little styles at the beginning of each `<styles lang="stylus">` section.** This is very helpful for injecting something like `@import "variables"` so that styles can have them preloaded into their context. Note that your probably shouldn't actually inject _real_ styles into each section. Instead, this is usually used to just load some variables or mixins so they can be used in the styles section without having to manually import them into each file.

2. **Gives a (currently, very opinionated) short syntax for `vue` files:**

Basically, why would you want to write your *.vue files like this:

```vue
<template lang="pug">
.app
  Header
  Sidebar
</template>

<script lang="coffee">
  import Header  from './Header'
  import Sidebar from './Sidebar'

  export default
    name: 'App'
    components: {
      Header,
      Sidebar,
    }
</script>

<style lang="stylus">
@import "~/src/styles/theme.styl"
</style>
```

When you could write them like this:

```coffee
template
  .app
    Header
    Sidebar

script
  import Header  from './Header'
  import Sidebar from './Sidebar'

  export default
    name: 'App'
    components: {
      Header,
      Sidebar,
    }

style
  @import "~/src/styles/theme.styl"
```
There is another small PR for the `vetur` extension to `vscode` that will support syntax highlighting for these mighty vue files. The changes to the `vue.yaml` file for the syntax are:

```yaml
# vues: pug, coffee, and stylus

- begin: (^template)\s*$
  beginCaptures:
    '1': {name: entity.name.tag.template.html}
  end: (?=^\S)
  patterns:
  - contentName: text.pug
    begin: ($)
    end: (?=^\S)
    patterns:
      - include: text.pug

- begin: (^script)\s*$
  beginCaptures:
    '1': {name: entity.name.tag.script.html}
  end: (?=^\S)
  patterns:
  - contentName: source.coffee
    begin: ($)
    end: (?=^\S)
    patterns:
      - include: source.coffee

- begin: (^style)\s*$
  beginCaptures:
    '1': {name: entity.name.tag.style.html}
  end: (?=^\S)
  patterns:
  - contentName: source.stylus
    begin: ($)
    end: (?=^\S)
    patterns:
      - include: source.stylus
```

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
